### PR TITLE
allow for clientIpKey to fallback with comma-separated list keys

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -47,14 +47,15 @@ class Input
     /* Getter for the client ip. */
     public function getClientIp()
     {
-        /* allow for comma-separated client IP keys */
-        $keys = explode(",",$this->options['clientIpKey']);
+        /* Allow for comma-separated client IP keys. */
+        $keys = explode(',', $this->options['clientIpKey']);
         foreach ($keys as $key) {
-            /* skip empty server keys */
-            if (!empty($_SERVER[$key]))
+            /* Skip empty server keys. */
+            if (!empty($_SERVER[$key])) {
                 return $_SERVER[$key];
+            }
         }
-        /* use the default or return empty */
+        /* Use the default or return empty string. */
         return empty($_SERVER['REMOTE_ADDR']) ? '' : $_SERVER['REMOTE_ADDR'];
     }
 

--- a/src/Input.php
+++ b/src/Input.php
@@ -50,9 +50,10 @@ class Input
         /* Allow for comma-separated client IP keys. */
         $keys = explode(',', $this->options['clientIpKey']);
         foreach ($keys as $key) {
+            $cleanKey = trim($key);
             /* Skip empty server keys. */
-            if (!empty($_SERVER[$key])) {
-                return $_SERVER[$key];
+            if (!empty($_SERVER[$cleanKey])) {
+                return $_SERVER[$cleanKey];
             }
         }
         /* Use the default or return empty string. */

--- a/src/Input.php
+++ b/src/Input.php
@@ -47,7 +47,15 @@ class Input
     /* Getter for the client ip. */
     public function getClientIp()
     {
-        return $_SERVER[$this->options['clientIpKey']];
+        /* allow for comma-separated client IP keys */
+        $keys = explode(",",$this->options['clientIpKey']);
+        foreach ($keys as $key) {
+            /* skip empty server keys */
+            if (!empty($_SERVER[$key]))
+                return $_SERVER[$key];
+        }
+        /* use the default or return empty */
+        return empty($_SERVER['REMOTE_ADDR']) ? '' : $_SERVER['REMOTE_ADDR'];
     }
 
     /* Getter for the caller. */


### PR DESCRIPTION
In some environments, it's possible that the host is accessible via multiple gateways. For example a load balancer for the public and a private network with direct access.

For this situation, I've allowed for the `clientIpKey` to contain a comma-separated list of `$_SERVER` keys to use in a check-and-fallback fashion. An example would be: `HTTP_X_FORWARDED_FOR,REMOTE_ADDR`.

If this feature is something desirable for inclusion upstream, I'll update the python and perl connectors to support the feature.