### PR TITLE
allow for X_FORWARD_FOR comma-separated addresses in getClientIp()

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -61,12 +61,12 @@ class Input
         /* Allow for comma-separated client IP keys. */
         $keys = explode(',', $this->options['clientIpKey']);
         foreach ($keys as $key) {
-            $cleanKey = trim($key);
+            $key = trim($key);
             /* Skip empty server keys. */
-            if (!empty($_SERVER[$cleanKey])) {
+            if (!empty($_SERVER[$key])) {
                 /* X_FORWARD_FOR allows for comma-separated address listing
-                 * and the first IP is assumed the actual client ip */
-                $addrs = explode(',',$_SERVER[$cleanKey]);
+                 * and the first IP is assumed the actual client IP. */
+                $addrs = explode(',', $_SERVER[$key]);
                 return array_shift($addrs);
             }
         }

--- a/src/Input.php
+++ b/src/Input.php
@@ -64,7 +64,10 @@ class Input
             $cleanKey = trim($key);
             /* Skip empty server keys. */
             if (!empty($_SERVER[$cleanKey])) {
-                return $_SERVER[$cleanKey];
+                /* X_FORWARD_FOR allows for comma-separated address listing
+                 * and the first IP is assumed the actual client ip */
+                $addrs = explode(',',$_SERVER[$cleanKey]);
+                return array_shift($addrs);
             }
         }
         /* Use the default or return empty string. */


### PR DESCRIPTION
I neglected to account for the comma-separated addresses when specifying things like X_FORWARD_FOR as the key. This fixes that problem by implementing the feature ([see wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For#Format)).